### PR TITLE
[Feat] 댓글 수정 기능 구현

### DIFF
--- a/src/main/java/challengers/findog/config/BaseResponseStatus.java
+++ b/src/main/java/challengers/findog/config/BaseResponseStatus.java
@@ -61,6 +61,9 @@ public enum BaseResponseStatus {
     //user/log-in
     NOT_EXISTS_USER(false, 3103, "일치하는 회원정보가 없습니다."),
 
+    //comment
+    FAILE_MODIFY_COMMENT(false, 3104, "댓글 수정에 실패하였습니다."),
+
 
     /**
      * 4000 : Database, Server 오류

--- a/src/main/java/challengers/findog/src/comment/CommentController.java
+++ b/src/main/java/challengers/findog/src/comment/CommentController.java
@@ -72,6 +72,7 @@ public class CommentController {
      * @param comment
      * @return
      */
+    @ApiOperation(value = "댓글 수정", notes = "JWT token 필요")
     @PatchMapping("")
     public BaseResponse<List<GetCommentRes>> modifyComment(@RequestBody Comment comment){
         try{

--- a/src/main/java/challengers/findog/src/comment/CommentController.java
+++ b/src/main/java/challengers/findog/src/comment/CommentController.java
@@ -17,6 +17,8 @@ import org.springframework.web.bind.annotation.*;
 import javax.validation.Valid;
 import java.util.List;
 
+import static challengers.findog.config.BaseResponseStatus.INVALID_USER_JWT;
+
 @Api(tags = "Comment")
 @RequiredArgsConstructor
 @RestController
@@ -60,6 +62,27 @@ public class CommentController {
         try{
             List<GetCommentRes> commentList = commentService.getCommentList(postId);
             return new BaseResponse<>(commentList);
+        } catch (BaseException e){
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+
+    /**
+     * 댓글 수정 API
+     * @param comment
+     * @return
+     */
+    @PatchMapping("")
+    public BaseResponse<List<GetCommentRes>> modifyComment(@RequestBody Comment comment){
+        try{
+            int userId = jwtService.getUserIdx();
+            if(userId != comment.getUserId()){
+                return new BaseResponse<>(INVALID_USER_JWT);
+            }
+
+            List<GetCommentRes> commentList = commentService.modifyComment(comment);
+            return new BaseResponse<>(commentList);
+
         } catch (BaseException e){
             return new BaseResponse<>(e.getStatus());
         }

--- a/src/main/java/challengers/findog/src/comment/CommentRepository.java
+++ b/src/main/java/challengers/findog/src/comment/CommentRepository.java
@@ -43,4 +43,11 @@ public class CommentRepository {
                         rs.getString("commentUpdateAt")
                 )), postId);
     }
+
+    //댓글 수정
+    public int modifyComment(Comment comment){
+        String query = "update Comment set content = ? where commentId = ? and userId = ?";
+        Object[] params = new Object[]{comment.getContent(), comment.getCommentId(), comment.getUserId()};
+        return jdbcTemplate.update(query, params);
+    }
 }

--- a/src/main/java/challengers/findog/src/comment/CommentService.java
+++ b/src/main/java/challengers/findog/src/comment/CommentService.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 import static challengers.findog.config.BaseResponseStatus.DATABASE_ERROR;
+import static challengers.findog.config.BaseResponseStatus.FAILE_MODIFY_COMMENT;
 
 @RequiredArgsConstructor
 @Service
@@ -49,6 +50,24 @@ public class CommentService {
 
             for(GetCommentRes comment : commentList){
                 comment.setCommentUpdateAt(changeDateFormat(comment.getCommentUpdateAt()));
+            }
+            return commentList;
+        } catch (Exception e){
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
+
+    //댓글 수정
+    @Transactional
+    public List<GetCommentRes> modifyComment(Comment comment) throws BaseException{
+        try{
+            if(commentRepository.modifyComment(comment) == 0){
+                throw new BaseException(FAILE_MODIFY_COMMENT);
+            }
+
+            List<GetCommentRes> commentList = commentRepository.getCommentList(comment.getPostId());
+            for(GetCommentRes cmt : commentList){
+                cmt.setCommentUpdateAt(changeDateFormat(cmt.getCommentUpdateAt()));
             }
             return commentList;
         } catch (Exception e){

--- a/src/main/java/challengers/findog/src/comment/model/Comment.java
+++ b/src/main/java/challengers/findog/src/comment/model/Comment.java
@@ -1,5 +1,6 @@
 package challengers.findog.src.comment.model;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -8,11 +9,24 @@ import java.sql.Timestamp;
 
 @Data
 public class Comment {
+    @ApiModelProperty(value = "commentId", example = "1", required = true)
     private int commentId;
+
+    @ApiModelProperty(hidden = true)
     private int parentCommentId;
+
+    @ApiModelProperty(value = "userId", example = "1", required = true)
     private int userId;
+
+    @ApiModelProperty(value = "postId", example = "1", required = true)
     private int postId;
+
+    @ApiModelProperty(value = "댓글 내용", example = "댓글입니다.", required = true)
     private String content;
+
+    @ApiModelProperty(hidden = true)
     private Timestamp commentCreateAt;
+
+    @ApiModelProperty(hidden = true)
     private Timestamp commentUpdateAt;
 }

--- a/src/main/java/challengers/findog/src/comment/model/Comment.java
+++ b/src/main/java/challengers/findog/src/comment/model/Comment.java
@@ -7,7 +7,6 @@ import lombok.Data;
 import java.sql.Timestamp;
 
 @Data
-@AllArgsConstructor
 public class Comment {
     private int commentId;
     private int parentCommentId;


### PR DESCRIPTION
## 댓글 수정 API
- JWT Token 필요
- RequestBody의 userId와 JWT를 통해 얻은 userId를 비교해서 수정 권한 확인 후 수정 가능
