### PR TITLE
[Feat] 댓글 삭제 기능 구현

### DIFF
--- a/src/main/java/challengers/findog/config/BaseResponseStatus.java
+++ b/src/main/java/challengers/findog/config/BaseResponseStatus.java
@@ -63,7 +63,7 @@ public enum BaseResponseStatus {
 
     //comment
     FAILE_MODIFY_COMMENT(false, 3104, "댓글 수정에 실패하였습니다."),
-
+    FAILE_DELETE_COMMENT(false, 3105, "댓글 삭제에 실패하였습니다."),
 
     /**
      * 4000 : Database, Server 오류

--- a/src/main/java/challengers/findog/src/comment/CommentController.java
+++ b/src/main/java/challengers/findog/src/comment/CommentController.java
@@ -10,6 +10,7 @@ import challengers.findog.src.comment.model.PostCommentReq;
 import challengers.findog.utils.JwtService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiKeyAuthDefinition;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.BindingResult;
@@ -97,6 +98,8 @@ public class CommentController {
      * @param deleteCommentRes
      * @return
      */
+    @ApiOperation(value = "댓글 삭제", notes = "JWT token 필요 , 대댓글이 있는 댓글은 commentStatus = 'deleted'로 변경")
+    @ApiImplicitParam(name = "postId", value = "게시글 ID", required = true, dataType = "int", paramType = "path")
     @DeleteMapping("/{postId}")
     public BaseResponse<List<GetCommentRes>> deleteComment(@PathVariable("postId") int postId, @RequestBody DeleteCommentRes deleteCommentRes) {
         try {

--- a/src/main/java/challengers/findog/src/comment/CommentController.java
+++ b/src/main/java/challengers/findog/src/comment/CommentController.java
@@ -4,6 +4,7 @@ import challengers.findog.config.BaseException;
 import challengers.findog.config.BaseResponse;
 import challengers.findog.config.BaseResponseStatus;
 import challengers.findog.src.comment.model.Comment;
+import challengers.findog.src.comment.model.DeleteCommentRes;
 import challengers.findog.src.comment.model.GetCommentRes;
 import challengers.findog.src.comment.model.PostCommentReq;
 import challengers.findog.utils.JwtService;
@@ -85,6 +86,29 @@ public class CommentController {
             return new BaseResponse<>(commentList);
 
         } catch (BaseException e){
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+
+    /**
+     * 댓글 삭제 API
+     * 대댓글이 있는 댓글인 경우는 삭제하지 않고 commentStatus = 'deleted'로 변경
+     * @param postId
+     * @param deleteCommentRes
+     * @return
+     */
+    @DeleteMapping("/{postId}")
+    public BaseResponse<List<GetCommentRes>> deleteComment(@PathVariable("postId") int postId, @RequestBody DeleteCommentRes deleteCommentRes) {
+        try {
+            int userId = jwtService.getUserIdx();
+            if (userId != deleteCommentRes.getUserId()) {
+                return new BaseResponse<>(INVALID_USER_JWT);
+            }
+
+            List<GetCommentRes> commentList = commentService.deleteComment(postId, deleteCommentRes);
+            return new BaseResponse<>(commentList);
+
+        } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());
         }
     }

--- a/src/main/java/challengers/findog/src/comment/CommentRepository.java
+++ b/src/main/java/challengers/findog/src/comment/CommentRepository.java
@@ -1,6 +1,7 @@
 package challengers.findog.src.comment;
 
 import challengers.findog.src.comment.model.Comment;
+import challengers.findog.src.comment.model.DeleteCommentRes;
 import challengers.findog.src.comment.model.GetCommentRes;
 import challengers.findog.src.comment.model.PostCommentReq;
 import challengers.findog.src.user.model.User;
@@ -40,7 +41,8 @@ public class CommentRepository {
                         rs.getString("profileUrl"),
                         rs.getInt("postId"),
                         rs.getString("content"),
-                        rs.getString("commentUpdateAt")
+                        rs.getString("commentUpdateAt"),
+                        rs.getString("commentStatus")
                 )), postId);
     }
 
@@ -49,5 +51,23 @@ public class CommentRepository {
         String query = "update Comment set content = ? where commentId = ? and userId = ?";
         Object[] params = new Object[]{comment.getContent(), comment.getCommentId(), comment.getUserId()};
         return jdbcTemplate.update(query, params);
+    }
+
+    //댓글 삭제
+    public int deleteComment(int commentId){
+        String query = "delete from Comment where commentId = ?";
+        return jdbcTemplate.update(query, commentId);
+    }
+
+    //대댓글이 있는 댓글 삭제
+    public int deleteParentComment(int commentId){
+        String query = "update Comment set commentStatus = 'deleted' where commentId = ?";
+        return jdbcTemplate.update(query, commentId);
+    }
+
+    //대댓글 존재 확인
+    public int checkParentComment(int commentId){
+        String query = "select exists (select commentId from Comment where parentCommentId = ?)";
+        return this.jdbcTemplate.queryForObject(query, int.class, commentId);
     }
 }

--- a/src/main/java/challengers/findog/src/comment/CommentService.java
+++ b/src/main/java/challengers/findog/src/comment/CommentService.java
@@ -3,6 +3,7 @@ package challengers.findog.src.comment;
 import challengers.findog.config.BaseException;
 import challengers.findog.config.BaseResponseStatus;
 import challengers.findog.src.comment.model.Comment;
+import challengers.findog.src.comment.model.DeleteCommentRes;
 import challengers.findog.src.comment.model.GetCommentRes;
 import challengers.findog.src.comment.model.PostCommentReq;
 import lombok.RequiredArgsConstructor;
@@ -11,8 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static challengers.findog.config.BaseResponseStatus.DATABASE_ERROR;
-import static challengers.findog.config.BaseResponseStatus.FAILE_MODIFY_COMMENT;
+import static challengers.findog.config.BaseResponseStatus.*;
 
 @RequiredArgsConstructor
 @Service
@@ -70,6 +70,26 @@ public class CommentService {
                 cmt.setCommentUpdateAt(changeDateFormat(cmt.getCommentUpdateAt()));
             }
             return commentList;
+        } catch (Exception e){
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
+
+    //댓글 삭제
+    public List<GetCommentRes> deleteComment(int postId, DeleteCommentRes deleteCommentRes) throws BaseException{
+        try{
+            if(commentRepository.checkParentComment(deleteCommentRes.getCommentId()) == 0){
+                if(commentRepository.deleteComment(deleteCommentRes.getCommentId()) == 0){
+                    throw new BaseException(FAILE_DELETE_COMMENT);
+                }
+            }
+            else{
+                if(commentRepository.deleteParentComment(deleteCommentRes.getCommentId()) == 0){
+                    throw new BaseException(FAILE_DELETE_COMMENT);
+                }
+            }
+
+            return getCommentList(postId);
         } catch (Exception e){
             throw new BaseException(DATABASE_ERROR);
         }

--- a/src/main/java/challengers/findog/src/comment/model/Comment.java
+++ b/src/main/java/challengers/findog/src/comment/model/Comment.java
@@ -1,5 +1,7 @@
 package challengers.findog.src.comment.model;
 
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -25,8 +27,17 @@ public class Comment {
     private String content;
 
     @ApiModelProperty(hidden = true)
+    private String commentStatus;
+
+    @ApiModelProperty(hidden = true)
     private Timestamp commentCreateAt;
 
     @ApiModelProperty(hidden = true)
     private Timestamp commentUpdateAt;
+
+
+    public Comment(int commentId, int userId){
+        this.commentId = commentId;
+        this.userId = userId;
+    }
 }

--- a/src/main/java/challengers/findog/src/comment/model/DeleteCommentRes.java
+++ b/src/main/java/challengers/findog/src/comment/model/DeleteCommentRes.java
@@ -1,9 +1,13 @@
 package challengers.findog.src.comment.model;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 
 @Data
 public class DeleteCommentRes {
+    @ApiModelProperty(value = "commentId", example = "1", required = true)
     private int commentId;
+
+    @ApiModelProperty(value = "userId", example = "1", required = true)
     private int userId;
 }

--- a/src/main/java/challengers/findog/src/comment/model/DeleteCommentRes.java
+++ b/src/main/java/challengers/findog/src/comment/model/DeleteCommentRes.java
@@ -1,0 +1,9 @@
+package challengers.findog.src.comment.model;
+
+import lombok.Data;
+
+@Data
+public class DeleteCommentRes {
+    private int commentId;
+    private int userId;
+}

--- a/src/main/java/challengers/findog/src/comment/model/GetCommentRes.java
+++ b/src/main/java/challengers/findog/src/comment/model/GetCommentRes.java
@@ -16,4 +16,5 @@ public class GetCommentRes {
     private int postId;
     private String content;
     private String commentUpdateAt;
+    private String commentStatus;
 }


### PR DESCRIPTION
## 댓글 삭제 기능
- JWT Token 필요
- 대댓글이 달린 댓글을 삭제할 경우, commentStatus = 'deleted'로 변경
- 대댓글이 없거나 대댓글을 삭제하는 경우는 즉각 튜플 삭제

### 추후 개선 사항
- 댓글에 대댓글을 달 수 있는 경우만 고려함
  - 만약, 대댓글에도 다시 대댓글을 달 수 있는 경우가 추가되면 변경 필요
