### PR TITLE
[Fix] 회원가입 프로필 사진 첨부 기능 수정

### DIFF
--- a/src/main/java/challengers/findog/src/user/UserService.java
+++ b/src/main/java/challengers/findog/src/user/UserService.java
@@ -42,7 +42,7 @@ public class UserService {
             throw new BaseException(PASSWORD_ENCRYPTION_ERROR);
         }
 
-        if(!postSignUpReq.getProfileImg().isEmpty() && postSignUpReq.getProfileImg() != null){
+        if(postSignUpReq.getProfileImg() != null && !postSignUpReq.getProfileImg().isEmpty()){
             if(!isRegexImage(postSignUpReq.getProfileImg().getOriginalFilename())){
                 throw new BaseException(INVALID_IMAGEFILEEXTENTION);
             }


### PR DESCRIPTION
## 회원가입 기능
회원가입 하는 부분에서 프로필 사진이 없을 경우, 
postman에서는 정상작동 
but 프론트단에서 form-data로 넘기는데 있어서 어려움 발생

- profileImg key 값 안보내도 되도록 코드 수정