### PR TITLE
[feat] 프로필 사진 수정 기능 구현

### DIFF
--- a/src/main/java/challengers/findog/src/mypage/MypageController.java
+++ b/src/main/java/challengers/findog/src/mypage/MypageController.java
@@ -3,10 +3,7 @@ package challengers.findog.src.mypage;
 import challengers.findog.config.BaseException;
 import challengers.findog.config.BaseResponse;
 import challengers.findog.config.BaseResponseStatus;
-import challengers.findog.src.mypage.model.GetCheckUserReq;
-import challengers.findog.src.mypage.model.PatchNicknameReq;
-import challengers.findog.src.mypage.model.PatchPasswordReq;
-import challengers.findog.src.mypage.model.PatchPhoneNumReq;
+import challengers.findog.src.mypage.model.*;
 import challengers.findog.utils.JwtService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.BindingResult;
@@ -102,6 +99,21 @@ public class MypageController {
         try{
             int userId = jwtService.getUserIdx();
             return new BaseResponse<>(mypageService.checkLogInInfo(getCheckUserReq, userId));
+        } catch (BaseException e){
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+
+    /**
+     * 프로필 이미지 수정 API
+     * @param patchProfileImgReq
+     * @return
+     */
+    @PatchMapping("/myInfo/profileImg")
+    public BaseResponse<String> modifyProfileImg(@ModelAttribute PatchProfileImgReq patchProfileImgReq) {
+        try{
+            int userId = jwtService.getUserIdx();
+            return new BaseResponse<>(mypageService.modifyProfileImg(patchProfileImgReq, userId));
         } catch (BaseException e){
             return new BaseResponse<>(e.getStatus());
         }

--- a/src/main/java/challengers/findog/src/mypage/MypageRepository.java
+++ b/src/main/java/challengers/findog/src/mypage/MypageRepository.java
@@ -3,6 +3,7 @@ package challengers.findog.src.mypage;
 import challengers.findog.src.mypage.model.PatchNicknameReq;
 import challengers.findog.src.mypage.model.PatchPasswordReq;
 import challengers.findog.src.mypage.model.PatchPhoneNumReq;
+import challengers.findog.src.mypage.model.PatchProfileImgReq;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
@@ -36,6 +37,19 @@ public class MypageRepository {
     public int modifyPassword(PatchPasswordReq patchPasswordReq, int userId){
         String query = "update User set password = ? where userId = ?";
         Object[] params = new Object[]{patchPasswordReq.getNewPassword(), userId};
+        return jdbcTemplate.update(query, params);
+    }
+
+    //프로필 이미지 삭제
+    public int deleteProfileImg(int userId){
+        String query = "update User set profileUrl = null where userId = ?";
+        return jdbcTemplate.update(query, userId);
+    }
+
+    //프로필 이미지 수정
+    public int modifyProfileImg(String profileImgUrl, int userId){
+        String query = "update User set profileUrl = ? where userId = ?";
+        Object[] params = new Object[]{profileImgUrl, userId};
         return jdbcTemplate.update(query, params);
     }
 }

--- a/src/main/java/challengers/findog/src/mypage/MypageService.java
+++ b/src/main/java/challengers/findog/src/mypage/MypageService.java
@@ -6,10 +6,12 @@ import challengers.findog.src.mypage.model.*;
 import challengers.findog.src.user.UserRepository;
 import challengers.findog.src.user.model.User;
 import challengers.findog.utils.AES128;
+import challengers.findog.utils.s3Component.FileControlService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import static challengers.findog.config.BaseResponseStatus.*;
+import static challengers.findog.utils.ValidationRegex.isRegexImage;
 
 
 @RequiredArgsConstructor
@@ -17,6 +19,7 @@ import static challengers.findog.config.BaseResponseStatus.*;
 public class MypageService {
     private final MypageRepository mypageRepository;
     private final UserRepository userRepository;
+    private final FileControlService fileControlService;
 
     //닉네임 수정
     public String modifyNickname(PatchNicknameReq patchNicknameReq, int userId) throws BaseException{
@@ -87,5 +90,40 @@ public class MypageService {
         }
 
         return "일치하는 회원 정보입니다.";
+    }
+
+    //프로필 이미지 수정
+    public String modifyProfileImg(PatchProfileImgReq patchProfileImgReq, int userId) throws BaseException{
+        if(patchProfileImgReq.getOriginProfileImgUrl() != null && !patchProfileImgReq.getOriginProfileImgUrl().equals("")){
+            fileControlService.deleteImage(patchProfileImgReq.getOriginProfileImgUrl());
+        }
+
+        if(patchProfileImgReq.getDeleteFlag() == 1){
+            if(mypageRepository.deleteProfileImg(userId) == 0){
+                throw new BaseException(FAIL_DELETE_PROFILEIMG);
+            }
+            return "프로필 사진이 성공적으로 삭제되었습니다.";
+        }
+
+        int result;
+
+        try{
+            if(patchProfileImgReq.getNewProfileImg() != null && !patchProfileImgReq.getNewProfileImg().isEmpty()) {
+                if (!isRegexImage(patchProfileImgReq.getNewProfileImg().getOriginalFilename())) {
+                    throw new BaseException(INVALID_IMAGEFILEEXTENTION);
+                }
+            }
+
+            String profileImgUrl = fileControlService.uploadImage(patchProfileImgReq.getNewProfileImg());
+            result = mypageRepository.modifyProfileImg(profileImgUrl, userId);
+        } catch (Exception e){
+            throw new BaseException(DATABASE_ERROR);
+        }
+
+        if(result == 0){
+            throw new BaseException(FAIL_MODIFY_PROFILEIMG);
+        }
+
+        return "프로필 사진을 성공적으로 수정하였습니다.";
     }
 }

--- a/src/main/java/challengers/findog/src/mypage/model/PatchProfileImgReq.java
+++ b/src/main/java/challengers/findog/src/mypage/model/PatchProfileImgReq.java
@@ -1,0 +1,11 @@
+package challengers.findog.src.mypage.model;
+
+import lombok.Data;
+import org.springframework.web.multipart.MultipartFile;
+
+@Data
+public class PatchProfileImgReq {
+    private MultipartFile newProfileImg;
+    private int deleteFlag;
+    private String originProfileImgUrl; //삭제할 이미지 => 기존 프로필
+}


### PR DESCRIPTION
## 프로필 사진 수정 API
- JWT 필요
### form data
- newProfileImg : 새로 바꿀 프로필 이미지
- deleteFlag : 기존 프로필 이미지를 삭제하고 기본 이미지로 변경하는 경우에 1 입력
- originProfileImgUrl : 기존 프로필 이미지 Url => s3에서 기존 프로필 이미지 삭제 위해 입력

### flow
- 프론트 단에서 프로필 수정 여부 확인해서 넘겨줌
- 기존 프로필을 삭제하는 경우에는 profileUrl에 null 저장
- 새로운 사진으로 업로드시 새로운 이미지 s3에 업로드 후 url 받아와서 업데이트
- 기존의 프로필 사진이 있는 경우에는 s3에서 삭제