### PR TITLE
[feat] 유기동물 공고 리스트 조회 기능 구현

### DIFF
--- a/src/main/java/challengers/findog/src/animal/AnimalController.java
+++ b/src/main/java/challengers/findog/src/animal/AnimalController.java
@@ -1,25 +1,37 @@
 package challengers.findog.src.animal;
 
+import challengers.findog.config.BaseException;
 import challengers.findog.config.BaseResponse;
+import challengers.findog.src.animal.model.GetAnimalListRes;
+import challengers.findog.src.animal.model.PageCriteriaDto;
 import challengers.findog.utils.JwtService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.net.URLEncoder;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/animal")
+@RequestMapping("/animals")
 public class AnimalController {
     private final AnimalService animalService;
     private final JwtService jwtService;
 
-
+    /**
+     * 유기동물 리스트 조회 API
+     * @param page
+     * @param size
+     * @return
+     */
+    @Transactional(readOnly = true)
+    @GetMapping("")
+    public BaseResponse<GetAnimalListRes> getAnimalPostList(@RequestParam(value = "page", defaultValue = "1") int page, @RequestParam(value = "size", defaultValue = "6") int size){
+        try{
+            return new BaseResponse<>(animalService.getAnimalPostList(jwtService.getJwt(), page, size));
+        } catch (BaseException e){
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
 }

--- a/src/main/java/challengers/findog/src/animal/AnimalRepository.java
+++ b/src/main/java/challengers/findog/src/animal/AnimalRepository.java
@@ -55,12 +55,13 @@ public class AnimalRepository {
         Object[] params = new Object[]{userId, size, (page - 1) * size};
         return jdbcTemplate.query(query,
                 (rs, rowNum) -> new AnimalSimpleDto(
+                        rs.getInt("animalId"),
                         rs.getString("processState"),
                         rs.getString("sexCd"),
                         rs.getString("neuterYn"),
                         rs.getString("kindCd"),
                         rs.getString("happenDt"),
-                        rs.getString("careNm"),
+                        rs.getString("orgNm"),
                         rs.getString("happenPlace"),
                         rs.getString("popfile"),
                         rs.getInt("likeFlag")

--- a/src/main/java/challengers/findog/src/animal/AnimalRepository.java
+++ b/src/main/java/challengers/findog/src/animal/AnimalRepository.java
@@ -1,11 +1,14 @@
 package challengers.findog.src.animal;
 
 import challengers.findog.src.animal.model.Animal;
+import challengers.findog.src.animal.model.AnimalSimpleDto;
+import challengers.findog.src.animal.model.PageCriteriaDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
 import javax.sql.DataSource;
+import java.util.List;
 
 @Repository
 public class AnimalRepository {
@@ -41,6 +44,33 @@ public class AnimalRepository {
                 animal.getCareAddr()
         };
         return jdbcTemplate.update(query, params);
+    }
+
+    //로그인 안한 사람이 유기동물 공고 조회
+    public List<AnimalSimpleDto> getAnimalPostList(int userId, int page, int size) {
+        String query = "select * " +
+                "from Animal left join (select animalId, if(userId > 0 , 1, 0) as likeFlag from `Like` where userId = ?) l on Animal.animalId = l.animalId " +
+                "order by noticeSdt desc, desertionNo desc " +
+                "limit ? offset ?";
+        Object[] params = new Object[]{userId, size, (page - 1) * size};
+        return jdbcTemplate.query(query,
+                (rs, rowNum) -> new AnimalSimpleDto(
+                        rs.getString("processState"),
+                        rs.getString("sexCd"),
+                        rs.getString("neuterYn"),
+                        rs.getString("kindCd"),
+                        rs.getString("happenDt"),
+                        rs.getString("careNm"),
+                        rs.getString("happenPlace"),
+                        rs.getString("popfile"),
+                        rs.getInt("likeFlag")
+                ), params);
+    }
+
+    //전체 유기동물 공고 개수
+    public int getAnimalPostTotalCount(){
+        String query = "select count(desertionNo) from Animal";
+        return jdbcTemplate.queryForObject(query, int.class);
     }
 
 }

--- a/src/main/java/challengers/findog/src/animal/model/AnimalSimpleDto.java
+++ b/src/main/java/challengers/findog/src/animal/model/AnimalSimpleDto.java
@@ -6,12 +6,13 @@ import lombok.Data;
 @Data
 @AllArgsConstructor
 public class AnimalSimpleDto {
+    private int animalId;
     private String processState;
     private String sexCd;
     private String neuterYn;
     private String kindCd;
     private String happenDt;
-    private String careNm;
+    private String orgNm;
     private String happenPlace;
     private String popfile;
 

--- a/src/main/java/challengers/findog/src/animal/model/AnimalSimpleDto.java
+++ b/src/main/java/challengers/findog/src/animal/model/AnimalSimpleDto.java
@@ -1,0 +1,19 @@
+package challengers.findog.src.animal.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class AnimalSimpleDto {
+    private String processState;
+    private String sexCd;
+    private String neuterYn;
+    private String kindCd;
+    private String happenDt;
+    private String careNm;
+    private String happenPlace;
+    private String popfile;
+
+    private int likeFlag;
+}

--- a/src/main/java/challengers/findog/src/animal/model/GetAnimalListRes.java
+++ b/src/main/java/challengers/findog/src/animal/model/GetAnimalListRes.java
@@ -1,0 +1,13 @@
+package challengers.findog.src.animal.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class GetAnimalListRes {
+    private PageCriteriaDto pageCriteria;
+    private List<AnimalSimpleDto> animalSimpleInfo;
+}

--- a/src/main/java/challengers/findog/src/animal/model/PageCriteriaDto.java
+++ b/src/main/java/challengers/findog/src/animal/model/PageCriteriaDto.java
@@ -1,0 +1,13 @@
+package challengers.findog.src.animal.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class PageCriteriaDto {
+    private int totalPostCount; //전체 동물공고 개수
+    private int totalPage; //전체 페이지 수
+    private int nowPage; //현재 페이지
+    private int pageSize; //해당 페이지에 표시할 동물 공고 개수
+}


### PR DESCRIPTION
## 유기동물 공고 리스트 조회 API
### Query String
- page : 조회할 page default = 1
- size : 한 페이지에 들어갈 유기동물 공고 개수 default = 6

### header
- JWT : 로그인을 한 계정에 한 해서 넘겨주면 됨. ==> 좋아요 누른 공고 확인 위함 